### PR TITLE
UnicodeEncodeError fixed

### DIFF
--- a/pinboard/pinboard.py
+++ b/pinboard/pinboard.py
@@ -55,8 +55,8 @@ class Bookmark(object):
         params = {
             'url': self.url,
             'description': self.description.encode("utf-8"),
-            'extended': self.extended,
-            'tags': self.tags,
+            'extended': self.extended.encode("utf-8"),
+            'tags': [t.encode("utf-8") for t in self.tags],
             'shared': "yes" if self.shared else "no",
             'toread': "yes" if self.toread else "no",
         }


### PR DESCRIPTION
Fixed UnicodeEncodeError while saving non-latin1 symbols in extended description or tags.
