### PR TITLE
handle 503 errors explicitly

### DIFF
--- a/pinboard/exceptions.py
+++ b/pinboard/exceptions.py
@@ -6,6 +6,9 @@ class PinboardError(Exception):
 class PinboardServerError(urllib2.HTTPError):
     pass
 
+class PinboardServiceUnavailable(urllib2.HTTPError):
+    pass
+
 class PinboardAuthenticationError(urllib2.HTTPError):
     pass
 

--- a/pinboard/pinboard.py
+++ b/pinboard/pinboard.py
@@ -172,9 +172,12 @@ class PinboardCall(object):
                 401: exceptions.PinboardAuthenticationError,
                 403: exceptions.PinboardForbiddenError,
                 500: exceptions.PinboardServerError,
+                503: exceptions.PinboardServiceUnavailable,
             }
-            Error = error_mappings[e.code]
-            raise Error(e.url, e.code, e.msg, e.hdrs, e.fp)
+            if e.code in error_mappings:
+                Error = error_mappings[e.code]
+                raise Error(e.url, e.code, e.msg, e.hdrs, e.fp)
+            raise
         else:
             if parse_response:
                 json_response = json.load(response)


### PR DESCRIPTION
Create an exception for 503 errors, when the API service is temporarily
offline. Also modify the error handling so if the error code is unknown
the original exception is thrown instead of a KeyError.
