### PR TITLE
Add rudimentary support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
   - "pypy"
 script: python setup.py test

--- a/pinboard/compat.py
+++ b/pinboard/compat.py
@@ -1,0 +1,21 @@
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    from urllib import urlencode
+    from urllib2 import build_opener, HTTPError, HTTPSHandler, Request
+    from urlparse import urlparse
+
+    def iteritems(d):
+        return d.iteritems()
+
+else:
+    from urllib.error import HTTPError
+    from urllib.parse import urlencode, urlparse
+    from urllib.request import build_opener, HTTPSHandler, Request
+
+    def iteritems(d):
+        return d.items()

--- a/pinboard/exceptions.py
+++ b/pinboard/exceptions.py
@@ -1,17 +1,18 @@
-import urllib2
+from .compat import HTTPError
+
 
 class PinboardError(Exception):
     pass
 
-class PinboardServerError(urllib2.HTTPError):
+class PinboardServerError(HTTPError):
     pass
 
-class PinboardServiceUnavailable(urllib2.HTTPError):
+class PinboardServiceUnavailable(HTTPError):
     pass
 
-class PinboardAuthenticationError(urllib2.HTTPError):
+class PinboardAuthenticationError(HTTPError):
     pass
 
-class PinboardForbiddenError(urllib2.HTTPError):
+class PinboardForbiddenError(HTTPError):
     pass
 

--- a/test_pinboard.py
+++ b/test_pinboard.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from pinboard import Pinboard
-import ConfigParser
 import datetime
 import os
 import unittest
@@ -9,6 +8,11 @@ import functools
 import time
 import random
 import string
+
+try:
+    from configparser import RawConfigParser
+except ImportError:
+    from ConfigParser import RawConfigParser
 
 class TestPinboardAPIPropagation(unittest.TestCase):
     def setUp(self):
@@ -45,7 +49,7 @@ class TestPinboardAPI(unittest.TestCase):
         if api_token is None:
             try:
                 config_file = os.path.expanduser("~/.pinboardrc")
-                config = ConfigParser.RawConfigParser()
+                config = RawConfigParser()
                 with open(config_file, "r") as f:
                     config.readfp(f)
             except:
@@ -104,7 +108,7 @@ class TestPinboardAPI(unittest.TestCase):
         return inner
 
     def check_meta_updated(self, bookmark_1, bookmark_2):
-        self.retry_until_true(lambda: bookmark_1 <> bookmark_2,
+        self.retry_until_true(lambda: bookmark_1 != bookmark_2,
                 msg="{} == {}".format(bookmark_1.meta, bookmark_2.meta))
 
     @ensure_last_update_time_changed


### PR DESCRIPTION
Right now, if you run `pip3 install pinboard` in a Python 3 virtualenv, it fails to install:

```console
$ pip install pinboard
Collecting pinboard
  Downloading pinboard-1.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/0d/p_z4b6f90g1gc8h9y87w0td80000gn/T/pip-build-87w6n5fp/pinboard/setup.py", line 6, in <module>
        from pinboard import metadata
      File "/private/var/folders/0d/p_z4b6f90g1gc8h9y87w0td80000gn/T/pip-build-87w6n5fp/pinboard/pinboard/__init__.py", line 1, in <module>
        from .pinboard import Pinboard
      File "/private/var/folders/0d/p_z4b6f90g1gc8h9y87w0td80000gn/T/pip-build-87w6n5fp/pinboard/pinboard/pinboard.py", line 5, in <module>
        import urllib2
    ImportError: No module named 'urllib2'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/0d/p_z4b6f90g1gc8h9y87w0td80000gn/T/pip-build-87w6n5fp/pinboard
You are using pip version 7.1.2, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

This patch adds basic support for Python 3. I ran `2to3` over the `pinboard` directory, and added a small compatibility file for the renamed parts of the standard library. Normally I’d use `six`, but you seem to be dependency-averse so I just wrote a new one.

I’ve tested this to the point that it installs and imports correctly in Python 3, but nothing more than that. There may be other subtle bugs lurking (string encoding is the big one) that I haven’t addressed. I might be using this library under Python 3, so I’ll open PRs if/when I find more Python 3-specific bugs.