### PR TITLE
Use config.read_file, fix DeprecationWarning

### DIFF
--- a/bin/pinboard
+++ b/bin/pinboard
@@ -42,7 +42,7 @@ class PinboardCommandLineHandler(object):
         try:
             config = configparser.RawConfigParser()
             with open(self.config_file, "r") as f:
-                config.readfp(f)
+                config.read_file(f)
         except:
             api_token = os.environ.get('PINBOARD_TOKEN') or self._login_action()
         else:

--- a/test_pinboard.py
+++ b/test_pinboard.py
@@ -47,7 +47,7 @@ class TestPinboardAPI(unittest.TestCase):
                 config_file = os.path.expanduser("~/.pinboardrc")
                 config = configparser.RawConfigParser()
                 with open(config_file, "r") as f:
-                    config.readfp(f)
+                    config.read_file(f)
             except:
                 raise
             else:


### PR DESCRIPTION
The main script used `config.readfp`, which was deprecated in Python 3.2, which is no longer listed as supported here. At some point in the past two years Python started emitting a warning that `readfp` will be removed in the future. 

The change seems to be very simple with no side effects.

This resolves #20. 